### PR TITLE
Add RunKit example

### DIFF
--- a/examples/runkit.js
+++ b/examples/runkit.js
@@ -1,0 +1,8 @@
+const R6API = require('r6api.js');
+const r6 = new R6API('example@mail.com', 'eatbigbanan');
+
+const username = 'Daniel.Nt';
+const id = await r6.getId('uplay', username).then(el => el[0].id);
+const stats = await r6.getStats('uplay', id).then(el => el[0]);
+
+console.log(`${username} has played ${stats.pvp.general.matches} matches`);

--- a/package.json
+++ b/package.json
@@ -31,5 +31,6 @@
   "bugs": {
     "url": "https://github.com/danielwerg/r6api.js/issues"
   },
-  "homepage": "https://github.com/danielwerg/r6api.js#readme"
+  "homepage": "https://github.com/danielwerg/r6api.js#readme",
+  "runkitExampleFilename": "examples/runkit.js"
 }


### PR DESCRIPTION
I've copied the example you put in the docs to a separate file to make it recognizable to RunKit: this way when you press "Test with RunKit" on the package npm page (or if you go to [npm.runkit.com/r6api.js](https://npm.runkit.com/r6api.js)) you should get the example right away. This is just to minimize confusion since RunKit gives a default name to the vars that is a little different from the one in the docs.

Sidenote: I've also pushed the v0.0.22 tag, make sure to push that too with `git push --tags` ;)