### PR TITLE
Add action to automate type generations

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,0 +1,30 @@
+name: Update TS files
+
+on: [push, pull_request]
+  
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Node.js
+      uses: actions/setup-node@v1
+      with:
+        nove-version: 10.x
+    - name: Install dependencies
+      run: npm install
+    - name: Regenerate definition files
+      run: npm run types:generate
+    - name: Commit changes
+      uses: EndBug/add-and-commit@v2.0.0
+      with:
+        author_name: Automation
+        author_email: actions@github.com
+        message: "[auto] Update typings"
+        path: typings
+        pattern: "*.*"
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      


### PR DESCRIPTION
This PR automates the updating of auto-generated type definitions using GitHub Actions: it will run the `types:generate` script on every push and pull requests, so that those types will be always up to date.
Please note that this will not affect anything that wouldn't be affected by the script: that means no breaking changes will be automatically "fixed" by this workflow.