### PR TITLE
Bump action versions in update workflow

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 5
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Set up Node.js 10.x
       uses: actions/setup-node@v1
       with:
@@ -28,10 +28,8 @@ jobs:
     - name: Regenerate definition files
       run: npm run types
     - name: Commit TypeScript changes
-      uses: EndBug/add-and-commit@v2.0.0
+      uses: EndBug/add-and-commit@v2
       with:
-        author_name: Automation
-        author_email: actions@github.com
         message: "[auto] Update typings"
         path: typings
         pattern: "*.*"
@@ -43,10 +41,8 @@ jobs:
         UBI_EMAIL: ${{ secrets.UBI_EMAIL }}
         UBI_PASSWORD: ${{ secrets.UBI_PASSWORD }}
     - name: Commit response changes
-      uses: EndBug/add-and-commit@v2.0.0
+      uses: EndBug/add-and-commit@v2
       with:
-        author_name: Automation
-        author_email: actions@github.com
         message: "[auto] Update response file"
         path: doc
         pattern: "*.*"


### PR DESCRIPTION
This PR makes the `update` workflow use the updated versions of these actions:

- `actions/checkout@v2`: it's faster and more resource-efficient than the previous version
- `EndBug/add-and-commit@v2`: by using the major version tag it automatically gets to use the updates (such as the use of the actor as the author for commits) without needing to worry about compatibility