### PR TITLE
Run update workflow only on master branch

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -6,6 +6,7 @@ on:
     - 'lib/methods/getStats.js'
     - 'lib/constants.js'
     - 'scripts/**'
+    branches: master
   pull_request:
     paths:
     - 'lib/methods/getStats.js'
@@ -19,6 +20,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        ref: master
     - name: Set up Node.js 10.x
       uses: actions/setup-node@v1
       with:


### PR DESCRIPTION
This should avoid `actions/checkout` creating new branches. Also, by running it only on the master branch you reduce the conflicts with PRs and stuff.