### PR TITLE
Fix 'update' workflow

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -31,11 +31,10 @@ jobs:
     - name: Regenerate definition files
       run: npm run types
     - name: Commit TypeScript changes
-      uses: EndBug/add-and-commit@v2
+      uses: EndBug/add-and-commit@v4
       with:
         message: "[auto] Update typings"
-        path: typings
-        pattern: "*.*"
+        add: typings
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Update full response file
@@ -44,10 +43,9 @@ jobs:
         UBI_EMAIL: ${{ secrets.UBI_EMAIL }}
         UBI_PASSWORD: ${{ secrets.UBI_PASSWORD }}
     - name: Commit response changes
-      uses: EndBug/add-and-commit@v2
+      uses: EndBug/add-and-commit@v4
       with:
         message: "[auto] Update response file"
-        path: doc
-        pattern: "*.*"
+        add: doc
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This makes the workflow use the latest version of add-and-commit
This should avoid errors like the ones in #27 ([link](https://github.com/danielwerg/r6api.js/pull/27/checks?check_run_id=544493693#step:6:10))