### PR TITLE
Mark userId nullable (Breaking Change)

### DIFF
--- a/src/methods/findById.ts
+++ b/src/methods/findById.ts
@@ -5,7 +5,7 @@ import { getURL, getAvatars } from '../utils';
 
 export interface IProfile {
   profileId: UUID;
-  userId: UUID;
+  userId: UUID | null;
   idOnPlatform: UUID | string;
   platformType: PlatformAllExtended;
   nameOnPlatform: string;

--- a/src/methods/findByUsername.ts
+++ b/src/methods/findByUsername.ts
@@ -5,7 +5,7 @@ import { getURL, getAvatars } from '../utils';
 
 export interface IProfile {
   profileId: UUID;
-  userId: UUID;
+  userId: UUID | null;
   idOnPlatform: UUID | string;
   platformType: PlatformAll;
   nameOnPlatform: string;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,10 +13,12 @@ import {
   STATS_CATEGORIES, GITHUB_ASSETS_URL
 } from './constants';
 
-export const getAvatarURL = (id: UUID, size = 256) =>
-  `${AVATARS_URL}/${id}/default_${size === 500 ? 'tall' : `${size}_${size}`}.png`;
+export const getAvatarURL = (id: UUID | null, size = 256) =>
+  id
+    ? `${AVATARS_URL}/${id}/default_${size === 500 ? 'tall' : `${size}_${size}`}.png`
+    : `${AVATARS_URL}/default_${size === 500 ? 'tall' : `${size}_${size}`}.png`;
 
-export const getAvatars = (id: UUID) => ({
+export const getAvatars = (id: UUID | null) => ({
   146: getAvatarURL(id, 146), 256: getAvatarURL(id, 256), 500: getAvatarURL(id, 500)
 });
 


### PR DESCRIPTION
In rare cases `userId` is `null`. I'm usure why but it seems to represent a linked account which doesn't started a game.
Raw API response to `nameOnPlatform` search: 
```json
{
    "profileId": "d3dde2ca-7c92-468e-89b4-9dab253225ce",
    "userId": null,
    "platformType": "psn",
    "idOnPlatform": "2072355385337540186",
    "nameOnPlatform": "AreYouAhueliTut"
}
```
Library response to `idOnPlatform` search: 
```json
  {
    "id": "07c8acb0-542a-4ad0-b0b0-0a714e346584",
    "userId": null,
    "idOnPlatform": "76561198106338458",
    "platform": "steam",
    "nameOnPlatform": "76561198106338458",
    "avatar": {
      "146": "https://ubisoft-avatars.akamaized.net/null/default_146_146.png",
      "256": "https://ubisoft-avatars.akamaized.net/null/default_256_256.png",
      "500": "https://ubisoft-avatars.akamaized.net/null/default_tall.png"
    }
  }
```
