### PR TITLE
Support crossplay progression 

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -23,8 +23,10 @@ export const AVATARS_URL = 'https://ubisoft-avatars.akamaized.net';
 export const CDN_URL = 'https://staticctf.akamaized.net';
 export const GITHUB_ASSETS_URL = 'https://github.com/danielwerg/r6api.js/raw/master/assets';
 
-export const PLATFORMS = <const>['uplay', 'psn', 'xbl'];
-export const PLATFORMSALL = <const>[...PLATFORMS, 'steam', 'epic', 'amazon'];
+// valid stats platforms with sandboxes
+export const PLATFORMS = <const>['uplay', 'psn', 'xbl', 'xplay'];
+// valid profile platforms
+export const PLATFORMSALL = <const>['uplay', 'psn', 'xbl', 'steam', 'epic', 'amazon'];
 
 // restructure this if pvp_newcomer will still return 500 in season 22
 export const BOARDS = <const>{

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,15 +5,18 @@ export const UBISERVICES_URL = 'https://public-ubiservices.ubi.com';
 export const STATUS_URL = 'https://game-status-api.ubisoft.com';
 export const UBI_URL = 'https://nimbus.ubisoft.com';
 
+// xplay ids https://github.com/Seems2Legit/Rainbow-Six-Siege-Player-Stats-API/issues/91#issuecomment-1362054176
 export const SPACE_IDS = <const>{
   uplay: '5172a557-50b5-4665-b7db-e3f2e8c5041d',
   psn: '05bfb3f7-6c21-4c42-be1f-97a33fb5cf66',
-  xbl: '98a601e5-ca91-4440-b1c5-753f601a2c90'
+  xbl: '98a601e5-ca91-4440-b1c5-753f601a2c90',
+  xplay: '0d2ae42d-4c27-4cb7-af6c-2099062302bb'
 };
 export const SANDBOXES = <const>{
   uplay: 'OSBOR_PC_LNCH_A',
   psn: 'OSBOR_PS4_LNCH_A',
-  xbl: 'OSBOR_XBOXONE_LNCH_A'
+  xbl: 'OSBOR_XBOXONE_LNCH_A',
+  xplay: 'OSBOR_XPLAY_LNCH_A'
 };
 
 export const AVATARS_URL = 'https://ubisoft-avatars.akamaized.net';

--- a/src/methods/getProgression.ts
+++ b/src/methods/getProgression.ts
@@ -1,7 +1,7 @@
 import { getToken } from '../auth';
 import fetch from '../fetch';
 import { Platform, UUID } from '../typings';
-import { getURL } from '../utils';
+import { getTotalXp, getURL } from '../utils';
 
 export interface IProgression {
   profile_id: UUID;
@@ -21,6 +21,7 @@ export default (platform: Platform, ids: UUID[]) =>
         id: profile.profile_id,
         level: profile.level,
         xp: profile.xp,
+        totalXp: getTotalXp(profile.level, profile.xp),
         lootboxProbability: {
           raw: profile.lootbox_probability,
           percent: profile.lootbox_probability

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -180,6 +180,40 @@ export const getURL = {
     '&tags=BR-rainbow-six%20GA-siege'
 };
 
+// Sources:
+// https://www.reddit.com/r/Rainbow6/comments/v8bidl/updated_xp_vs_clearance_level_chart_up_to_lvl800/
+// https://docs.google.com/spreadsheets/d/1zP-dZgV3RHGswj1Wtz2wZs6Nr7RZc7syT2_kdM4L8mU/edit?usp=sharing
+const firstLevels = [
+  0, 500, 1500, 3500, 3500, 4000, 4000, 4500, 4500, 4500, 5500, 5500
+] as const;
+
+export const getXpPerLevel = (level: number): number => {
+  if (!Number.isInteger(level)) return NaN;
+  else if (39 <= level) return -9000 + 500 * level;
+  else if (12 <= level && level < 39) return 4000 + 500 * ((level / 3) >> 0);
+  else if (0 <= level && level < 12) return firstLevels[level] ?? NaN;
+  else return NaN;
+};
+
+export const getTotalXp = (level: number, xp = 0): number => {
+  if (!Number.isInteger(level) || level < 0) return NaN;
+  let sum = 0;
+  for (; level > 0; level--) sum += getXpPerLevel(level);
+  return sum + xp;
+};
+
+export const getLevelByXp = (xp: number) => {
+  if (!Number.isInteger(xp) || xp < 0) return NaN;
+  let level = 0,
+      currentXp = 0;
+  for (; xp >= (currentXp = getXpPerLevel(level)); level++) xp -= currentXp;
+  return level - 1;
+};
+
+export const getXpRemainder = (xp: number) => {
+  return xp - getTotalXp(getLevelByXp(xp));
+};
+
 export const isPlatform = (value: string): value is Platform =>
   PLATFORMS.map(platform => platform.toString()).includes(value);
 


### PR DESCRIPTION
After crossplay release `r6api.getProgression` no longer receive updates.
My current xp and level: 
![image](https://github.com/danielwerg/r6api.js/assets/16510197/a21514c1-df76-4b83-b0d0-fbbee0e7b2b7)
My xp and level from legacy progression endpoint:
```http
GET /v1/spaces/5172a557-50b5-4665-b7db-e3f2e8c5041d/sandboxes/OSBOR_PC_LNCH_A/r6playerprofile/playerprofile/progressions?profile_ids=c09fc7c9-5d45-4c6c-94e5-2dee159abff3 HTTP/1.1
Host: public-ubiservices.ubi.com
Authorization: Ubi_v1 t=<token>
Ubi-AppId: e3d5ea9e-50bd-43b7-88bf-39794f4e3d40
```
```json
{
    "player_profiles": [
        {
            "xp": 25362,
            "profile_id": "c09fc7c9-5d45-4c6c-94e5-2dee159abff3",
            "lootbox_probability": 650,
            "level": 281
        }
    ]
}
```
While we have been researching for Ranked 2.0 @floxay provided [new sandbox name and space id](https://github.com/Seems2Legit/Rainbow-Six-Siege-Player-Stats-API/issues/91#issuecomment-1362054176) for crossplay.
My xp and level from new crossplay progression endpoint:
```http
GET /v1/spaces/0d2ae42d-4c27-4cb7-af6c-2099062302bb/sandboxes/OSBOR_XPLAY_LNCH_A/r6playerprofile/playerprofile/progressions?profile_ids=c09fc7c9-5d45-4c6c-94e5-2dee159abff3 HTTP/1.1
Host: public-ubiservices.ubi.com
Authorization: Ubi_v1 t=<token>
Ubi-AppId: e3d5ea9e-50bd-43b7-88bf-39794f4e3d40
```
```json
{
    "player_profiles": [
        {
            "xp": 4472,
            "profile_id": "c09fc7c9-5d45-4c6c-94e5-2dee159abff3",
            "lootbox_probability": 600,
            "level": 89
        }
    ]
}
```
As you can see, both results are incorrect. It would be reasonable for Ubisoft (lol) to use the sum of legacy and crossplay xp. But there's no total xp in API response, only level and xp remainder. Using some redditor [research](https://www.reddit.com/r/Rainbow6/comments/v8bidl/updated_xp_vs_clearance_level_chart_up_to_lvl800/) I wrote few functions in [Google Sheets](https://docs.google.com/spreadsheets/d/1zP-dZgV3RHGswj1Wtz2wZs6Nr7RZc7syT2_kdM4L8mU/edit?usp=sharing) to calculate xp per level, total xp, level and remainder by total xp. 
NOTE: there's a constant 500xp difference with the calculated and actual result. Looks like Ubisoft added 500xp to legacy profiles after freezing it.
So now I can import these functions from utils, call `r6api.getProgression('uplay', id)` and `r6api.getProgression('xplay', id)`, merge total xp and calculate the actual level and xp remainder.
If @danielwerg decide he could add a unified method to collect and merge progression from all sandboxes, but such method is not ratelimit friendly. 